### PR TITLE
修正状态栏计时器文字显示

### DIFF
--- a/src/service/StatusBarTimeService.ts
+++ b/src/service/StatusBarTimeService.ts
@@ -112,7 +112,7 @@ class StatusBarTimeService implements Disposable {
       if (this.questionNode?.id) {
         pre = `${this.questionNode?.id}题`;
       }
-      this.showBar.text = `${pre}计时:${diffstr}`;
+      this.showBar.text = `${pre}计时: ${diffstr}`;
     } else if (this.saveTime > 0) {
       let diff = this.saveTime;
       let diffstr = this.getDiffStr(diff);
@@ -120,9 +120,9 @@ class StatusBarTimeService implements Disposable {
       if (this.questionNode?.id) {
         pre = `${this.questionNode?.id}题`;
       }
-      this.showBar.text = `${pre}题计时:${diffstr}`;
+      this.showBar.text = `${pre}计时: ${diffstr}`;
     } else {
-      this.showBar.text = `做题计时:${this.getDiffStr(0)}`;
+      this.showBar.text = `做题计时: ${this.getDiffStr(0)}`;
     }
   }
 


### PR DESCRIPTION
修正了一个问题：状态栏计时器暂停时，前部文字中会多出一个「题」字。如图所示：

![bug](https://user-images.githubusercontent.com/83903009/213902912-b1a5c8c3-6b7a-436d-b4e6-b4fa1cb20d81.png)
