### PR TITLE
修正提交结果页面耗时显示

### DIFF
--- a/src/service/SubmissionService.ts
+++ b/src/service/SubmissionService.ts
@@ -23,8 +23,9 @@ class SubmissionService extends BaseWebViewService {
     this.result = this.parseResult(resultString);
 
     const temp = this.getSubmitEvent();
-    if (temp?.accepted && temp?.sub_type == "submit") {
-      this.result["costTime"] = [`耗时${statusBarTimeService.getCostTimeStr()}`];
+    let costTime = statusBarTimeService.getCostTimeStr();
+    if (temp?.accepted && temp?.sub_type == "submit" && costTime) {
+      this.result["costTime"] = [`耗时 ${costTime}`];
     }
     this.showWebviewInternal();
     this.showKeybindingsHint();


### PR DESCRIPTION
修正了一个问题：若直接打开某题的解答代码并点击提交，由于未手动点击开始计时，提交结果页面会显示「耗时undefined」。修正后，若未计时，则提交结果页面不会显示做题耗时。